### PR TITLE
Calculate number overlap after other settings are parsed

### DIFF
--- a/nndetector_learn.m
+++ b/nndetector_learn.m
@@ -24,7 +24,6 @@ neg_examples=[]; % negative examples (calls/cage noise, etc.)
 gui_enable=1; % requires jmarkow/zftftb toolbox
 fft_size = 128; % fft size in samples
 fft_time_shift = 0.01; % timestep in seconds
-noverlap = fft_size - (floor(samplerate * fft_time_shift));
 ntrain = 1000;
 scaling= 'db'; % ('lin','log', or 'db', scaling for spectrograms)
 
@@ -64,6 +63,9 @@ for i=1:2:nparams
       scaling=varargin{i+1};
 	end
 end
+
+% calculate the number of overlaps
+noverlap = fft_size - (floor(samplerate * fft_time_shift));
 
 if ~isempty(padding) & length(padding)==2
   pad_smps=round(padding*FS);


### PR DESCRIPTION
I am not sure if this is causing any of the bugs we saw, but it appears that the `noverlap` variable is calculated before parsing the function arguments, specifically `samplerate`, `fft_size` and `fft_time_shift`. As a result, the `noverlap` used for training the network will be different than what is described by the other variables and hence what is parsed by Swift.
